### PR TITLE
[Fix] Configure Super-Linter to ignore Helm templates (2)

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,59 @@
+---
+###########################################
+# These are the rules used for            #
+# linting all the yaml files in the stack #
+# NOTE:                                   #
+# You can disable line with:              #
+# # yamllint disable-line                 #
+###########################################
+rules:
+  braces:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 5
+  brackets:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 5
+  colons:
+    level: warning
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    level: warning
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start:
+    level: warning
+    present: true
+  empty-lines:
+    level: warning
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    level: warning
+    max-spaces-after: 1
+  indentation:
+    level: warning
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length:
+    level: warning
+    max: 80
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -6,6 +6,11 @@
 # You can disable line with:              #
 # # yamllint disable-line                 #
 ###########################################
+
+# Ignore Helm templates
+ignore: |
+  templates
+
 rules:
   braces:
     level: warning

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,8 +57,8 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Do not lint downloaded code - see https://github.com/github/super-linter
-          FILTER_REGEX_EXCLUDE: .*/download/.*
+          # Do not lint Helm templates - see https://github.com/github/super-linter
+          FILTER_REGEX_EXCLUDE: .*/templates/.*
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_TYPESCRIPT_STANDARD: false
           TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.json


### PR DESCRIPTION
It looks like that Super-Linter (actually, kubeval) complains on Helm templates generated by the "helm create" command.

While waiting for the official fix, temporarily disable checks on templates.

Closing #7

(this is the second attempt, after #10)

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>